### PR TITLE
cu/result: return error code for undefined errors

### DIFF
--- a/result.go
+++ b/result.go
@@ -2,23 +2,25 @@ package cu
 
 //#include <cuda.h>
 import "C"
+import "fmt"
 
 // cuResult is the Go version of CUresult:
 // http://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1gc6c391505e117393cc2558fff6bfc2e9
 type cuResult int
 
 func (err cuResult) Error() string  { return err.String() }
-func (err cuResult) String() string { return resString[err] }
+func (err cuResult) String() string {
+    if msg, ok := resString[err]; ok {
+        return msg
+    }
+    return fmt.Sprintf("UnknownErrorCode:%d", err)
+}
 
 func result(x C.CUresult) error {
 	err := cuResult(x)
 	if err == Success {
 		return nil
 	}
-	if err > Unknown {
-		return Unknown
-	}
-
 	return err
 }
 


### PR DESCRIPTION
cuResult values have gaps. If new errors are added, they can have a value less than CUDA_ERROR_UNKNOWN.

This change returns the error code as part of the error string when the error isn't defined in resString.