### PR TITLE
Fixed install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ However, package `cu` DOES depend on one major external dependency: CUDA. Specif
 To verify that this library works, install and run the `cudatest` program, which accompanies this package:
 
 ```
-go install gorgonia.org/cu/cmd/cudatest
+go install gorgonia.org/cu/cmd/cudatest@latest
 cudatest
 ```
 


### PR DESCRIPTION
Hi, `go install` needs a tag to function:

![image](https://user-images.githubusercontent.com/31022056/201524604-eac26d5a-02a6-49d4-ad43-b156c58ecc3c.png)

This PR adds the `latest` tag to always install the latest release.