### PR TITLE
Add CUDA 11.8 and alternative means of setting up cgo on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,16 @@ To setup CUDA in Windows:
 2. Add `%CUDA_PATH%/bin` to your `%PATH%` environment variable (running `nvcc` from console should work)
 3. Make a symlink `mklink /D C:\cuda "c:\Program Files\NVIDIA GPU Computing Toolkit\CUDA"` (alternatively, install CUDA toolkit to `C:\cuda\`)
 
-To setup the compiler:
+To setup the compiler chain (MSYS2):
 
 1. Install MSYS2 (see https://www.msys2.org/)
 2. In `c:\msys64\msys2_shell.cmd` uncomment the line with `set MSYS2_PATH_TYPE=inherit` (this makes Windows PATH variable visible)
 3. Install `go` in MSYS2 (64 bit) with `pacman -S go`
+
+Alternatively, if you already have Go setup and only need to install cgo dependencies:
+
+1. Install TDM-GCC (see https://jmeubank.github.io/tdm-gcc/download/)
+2. Ensure `gcc` is in `%PATH%` environment variable (running `gcc` from console should work)
 
 ## FAQ ##
 

--- a/cgoflags.go
+++ b/cgoflags.go
@@ -26,6 +26,6 @@ package cu
 //#cgo darwin CFLAGS: -I/usr/local/cuda/include/
 //
 ////WINDOWS:
-//#cgo windows LDFLAGS:-LC:/cuda/v5.0/lib/x64 -LC:/cuda/v5.5/lib/x64 -LC:/cuda/v6.0/lib/x64 -LC:/cuda/v6.5/lib/x64 -LC:/cuda/v7.0/lib/x64 -LC:/cuda/v8.0/lib/x64 -LC:/cuda/v9.0/x64
-//#cgo windows CFLAGS: -IC:/cuda/v5.0/include -IC:/cuda/v5.5/include -IC:/cuda/v6.0/include -IC:/cuda/v6.5/include -IC:/cuda/v7.0/include -IC:/cuda/v8.0/include -IC:/cuda/v9.0/include
+//#cgo windows LDFLAGS:-LC:/cuda/v5.0/lib/x64 -LC:/cuda/v5.5/lib/x64 -LC:/cuda/v6.0/lib/x64 -LC:/cuda/v6.5/lib/x64 -LC:/cuda/v7.0/lib/x64 -LC:/cuda/v8.0/lib/x64 -LC:/cuda/v9.0/x64 -LC:/cuda/v11.8/lib/x64
+//#cgo windows CFLAGS: -IC:/cuda/v5.0/include -IC:/cuda/v5.5/include -IC:/cuda/v6.0/include -IC:/cuda/v6.5/include -IC:/cuda/v7.0/include -IC:/cuda/v8.0/include -IC:/cuda/v9.0/include -IC:/cuda/v11.8/include
 import "C"

--- a/nvrtc/cgoflags.go
+++ b/nvrtc/cgoflags.go
@@ -27,6 +27,6 @@ package nvrtc
 //#cgo darwin CFLAGS: -I/usr/local/cuda/include/
 //
 ////WINDOWS:
-//#cgo windows LDFLAGS:-LC:/cuda/v5.0/lib/x64 -LC:/cuda/v5.5/lib/x64 -LC:/cuda/v6.0/lib/x64 -LC:/cuda/v6.5/lib/x64 -LC:/cuda/v7.0/lib/x64 -LC:/cuda/v8.0/lib/x64 -LC:/cuda/v9.0/x64
-//#cgo windows CFLAGS: -IC:/cuda/v5.0/include -IC:/cuda/v5.5/include -IC:/cuda/v6.0/include -IC:/cuda/v6.5/include -IC:/cuda/v7.0/include -IC:/cuda/v8.0/include -IC:/cuda/v9.0/include
+//#cgo windows LDFLAGS:-LC:/cuda/v5.0/lib/x64 -LC:/cuda/v5.5/lib/x64 -LC:/cuda/v6.0/lib/x64 -LC:/cuda/v6.5/lib/x64 -LC:/cuda/v7.0/lib/x64 -LC:/cuda/v8.0/lib/x64 -LC:/cuda/v9.0/x64 -LC:/cuda/v11.8/lib/x64
+//#cgo windows CFLAGS: -IC:/cuda/v5.0/include -IC:/cuda/v5.5/include -IC:/cuda/v6.0/include -IC:/cuda/v6.5/include -IC:/cuda/v7.0/include -IC:/cuda/v8.0/include -IC:/cuda/v9.0/include -IC:/cuda/v11.8/include
 import "C"


### PR DESCRIPTION
Hi,

After some initial problem I'm finally able to compile the `cudatest/main.go` in Windows 10. I need to add `-LC:/cuda/v11.8/lib/x64` and `-IC:/cuda/v11.8/include` to `cgoflags.go` since the version of CUDA I just downloaded is now v11.8.

Perhaps there's a better way of future-proofing this entry? maybe rewriting the symlink method defined in readme to also include the version numbers like `mklink /D C:\cuda "c:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\"`, then adding `-LC:/cuda/lib/x64` to `cgoflags.go`?

Additionally as I already have an existing Go development environment setup, I had some difficulty compiling using the msys method defined in the readme. What I found is that by installing TDM-GCC, `cgo` simply works without further configuration. I'd like to add this on the readme if it's acceptable.

Thanks.